### PR TITLE
modified streamlit startup command to include port 5001

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,4 +48,4 @@ COPY . /app
 EXPOSE 5001
 
 # Set the default command to run Streamlit
-CMD ["conda", "run", "-n", "myenv", "streamlit", "run", "app.py"]
+CMD ["conda", "run", "-n", "myenv", "streamlit", "run", "app.py", "--server.port=5001"]


### PR DESCRIPTION
- while running the streamlit startup command without specifying any port, the default container port that is being used is 8501, changed it to 5001.