### PR TITLE
Refactor using Miniforge Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-# Use the official Ubuntu image as a parent image
-FROM python:3.12-slim
+# Use Miniforge base image
+FROM condaforge/mambaforge:latest
 
 # Set environment variables
 ENV LANG=C.UTF-8
@@ -7,49 +7,18 @@ ENV DEBIAN_FRONTEND=noninteractive
 ENV PYTHONUNBUFFERED=1
 ENV PYTHONDONTWRITEBYTECODE=1
 
-# Set the working directory
+# Set working directory
 WORKDIR /app
 
-# Install system dependencies including wget, curl, and bzip2
-RUN apt-get update && apt-get install -y \
-    gcc \
-    g++ \
-    git \
-    curl \
-    wget \
-    bzip2 \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
-
-# Install Miniforge
-RUN curl -L -O "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh" && \
-    bash Miniforge3-$(uname)-$(uname -m).sh -b -p /opt/conda && \
-    rm Miniforge3-$(uname)-$(uname -m).sh
-
-# Add Conda to the PATH environment variable
-ENV PATH=/opt/conda/bin:$PATH
-
-# Create a Conda environment using Mamba and install Python packages from environment.yml
-RUN mamba create -n team1_env python=3.12 -y
-
-# Copy the environment.yml and requirements.txt files to the working directory
-#COPY environment.yml /app/environment.yml
-COPY requirements.txt /app/requirements.txt
-
-# Activate the environment for subsequent commands
-SHELL ["mamba", "run", "-n", "team1_env", "/bin/bash", "-c"]
-
-# Install pip packages from requirements.txt
-RUN mamba install --yes --file requirements.txt && mamba clean --all -f -y
-
-# Copy the rest of the application code
+# Copy application files
 COPY . /app
 
-# Expose ports
+# Install necessary packages through requirements.txt
+RUN mamba install --yes --file requirements.txt && mamba clean --all -f -y
+
+# Expose port
 EXPOSE 5001
 
-# Add the conda environment's bin directory to PATH
-ENV PATH=/opt/conda/envs/team1_env/bin:$PATH
-
+# Run the Streamlit application
 ENTRYPOINT ["python"]
 CMD ["app.py"]

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Before you begin, make sure you have the following installed on your machine:
 
 3. **Update the local repository**
 
-   Ensureyour local repository is up to date by running:
+   Ensure your local repository is up to date by running:
 
    ```bash
    git pull origin main
@@ -44,7 +44,7 @@ Before you begin, make sure you have the following installed on your machine:
    Build the Docker image using the following command:
 
    ```bash
-   docker build --no-cache -t team1_app:latest .
+   docker build -t team1_app:latest .
    ```
 
 5. **Run the Docker container**

--- a/environment.yml
+++ b/environment.yml
@@ -1,9 +1,0 @@
-name: myenv
-channels:
-  - conda-forge
-dependencies:
-  - python=3.12
-  - streamlit
-  - langchain
-  - faiss-cpu
-  - pip

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 streamlit
 jupyter
+langchain
+faiss-cpu

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ streamlit
 jupyter
 langchain
 faiss-cpu
+mistralai


### PR DESCRIPTION
* Switched to the Miniforge Docker image which comes with python 3.12 and mamba preinstalled and configured
    * May need to manually downgrade to python 3.11 or below based on dependencies from requirements
* Changed the requirements file to include all packages which can be installed easily from file
    * NeMo, Mistral, Milvus all have dependencies which are installed independently from mamba (Pytorch, etc.)
        * They also are quite big installs (NeMo alone is 30GB compressed which until necessary should probably not be included)
* Removed the --no-cache from the build command
    * Was originally added to prevent caching dockerfile. The build command will use the cached version whenever the RUN commands are unmodified. Helps speed up build time when the dockerfile is unchanged. Each run will still import the new app.py and will prevent the unnecessary rebuild of the dockerfile when nothing has changed in it. 
