### PR TITLE
Update NGINX and Jupyter ports

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -58,7 +58,7 @@ EXPOSE 80
 # Streamlit port
 EXPOSE 5001
 # Jupyter Notebook port
-EXPOSE 8888
+EXPOSE 6001
 
 # Add the conda environment's bin directory to PATH
 ENV PATH=/opt/mambaforge/envs/team1_env/bin:$PATH

--- a/README.md
+++ b/README.md
@@ -52,14 +52,14 @@ Before you begin, make sure you have the following installed on your machine:
    Run the Docker container with the following command:
 
    ```bash
-   docker run -d -p 80:80 -p 5001:5001 -p 8888:8888 team1_app
+   docker run -d -p 81:80 -p 5001:5001 -p 6001:6001 team1_app
    ```
 
 ### Accessing the Application
 
 Once the Docker container is running, you can access the IT Support Chatbot through your browser at:
 
-[http://localhost:5001](http://localhost:5001), [http://localhost/team1/](http://localhost/team1/)
+[http://localhost:5001](http://localhost:5001), [http://localhost:81/team1/](http://localhost:81/team1/)
 
 ---
 

--- a/app.py
+++ b/app.py
@@ -65,4 +65,4 @@ if __name__ == "__main__":
         os.environ["STREAMLIT_RUNNING"] = "1"  # Set the environment variable to indicate Streamlit is running
         subprocess.Popen(["streamlit", "run", __file__, "--server.port=5001", "--server.address=0.0.0.0"])
         subprocess.Popen(["service", "nginx", "start"])
-        subprocess.run(["jupyter", "notebook", "--ip=0.0.0.0", "--port=8888", "--no-browser", "--allow-root"])
+        subprocess.run(["jupyter", "notebook", "--ip=0.0.0.0", "--port=6001", "--no-browser", "--allow-root"])


### PR DESCRIPTION
As per Dr. Alzahrani on Team1 Discussion

Port Changes
* Uses docker -p 81:80 to redirect HTTP 81 to nginx 80 in docker
* Changes Jupyter notebook to port 6001

This changes the functionality of our `localhost/team1/` and it instead can be view on `localhost:81/team1/`

From my limited understanding of nginx, it seems that much further configuration is needed to have nginx run on port 81 instead of port 80. So instead of changing our entire configuration we use docker port connections to connect HTTP 81 to our dockers port 80

The change in accessible address may be fixable but also from my understanding `localhost` is equivalent to `localhost:80` and thus we may be required to specify port 81