### PR TITLE
NeMo Dockerfile installation 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,8 @@ RUN apt-get update && apt-get install -y \
 	wget \
 	bzip2 \
 	ca-certificates \
+	build-essential \
+    python3-dev \
 	&& rm -rf /var/lib/apt/lists/*
 
 # Install Mambaforge for the appropriate architecture
@@ -47,7 +49,8 @@ COPY requirements.txt /app/requirements.txt
 RUN mamba install --yes --file requirements.txt && mamba clean --all -f -y
 
 # Install Python packages not on Mamba DB
-RUN pip install -qU langchain_milvus langchain-cohere
+RUN pip install -qU cython
+RUN pip install -qU langchain_milvus langchain-cohere nemo-curator nemoguardrails
 
 # Copy the current directory contents into the container at /app
 COPY . /app

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ sentence-transformers
 faiss-cpu
 mistralai
 pymilvus
+pydantic==2.5.2


### PR DESCRIPTION
Installs NeMo curator and NeMo guardrails via Dockerfile. Issue resolved in issue #96. 