### PR TITLE
Error handling for --mount in Dockerfile

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -35,5 +35,3 @@ jobs:
           tags: ${{ vars.DOCKERHUB_USERNAME }}/team1_app:latest
           secrets: |
             "MISTRAL_API_KEY=${{ secrets.MISTRAL_API_KEY }}"
-          build-args: |
-            DOCKER_BUILD_VIA_WORKFLOW=true

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -3,11 +3,10 @@ name: ci
 on:
   push:
     branches:
-      - Github-workflow-for-API
+      - Docker-mount-fix
       - main
   pull_request:
     branches:
-      - Github-workflow-for-API
       - main
 
 jobs:
@@ -36,3 +35,5 @@ jobs:
           tags: ${{ vars.DOCKERHUB_USERNAME }}/team1_app:latest
           secrets: |
             "MISTRAL_API_KEY=${{ secrets.MISTRAL_API_KEY }}"
+          build-args: |
+            DOCKER_BUILD_VIA_WORKFLOW=true

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,18 +8,12 @@ ENV DEBIAN_FRONTEND=noninteractive
 ENV PYTHONUNBUFFERED=1
 ENV PYTHONDONTWRITEBYTECODE=1
 
-ARG DOCKER_BUILD_VIA_WORKFLOW="false"
-
 # Set the working directory in the container
 WORKDIR /app
 
 # Import secret and save to .ENV file
 RUN --mount=type=secret,id=MISTRAL_API_KEY \
 		echo "MISTRAL_API_KEY=$(cat /run/secrets/MISTRAL_API_KEY)" > /app/.env
-
-# Import secret as ENV and save to .ENV file
-#RUN --mount=type=secret,id=MISTRAL_API_KEY,env=MISTRAL_API_KEY || true \
-#	echo "MISTRAL_API_KEY=${MISTRAL_API_KEY}" > /app/.env
 
 # Update and install necessary packages
 RUN apt-get update && apt-get install -y \

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,17 +8,14 @@ ENV DEBIAN_FRONTEND=noninteractive
 ENV PYTHONUNBUFFERED=1
 ENV PYTHONDONTWRITEBYTECODE=1
 
+ARG DOCKER_BUILD_VIA_WORKFLOW="false"
+
 # Set the working directory in the container
 WORKDIR /app
 
-# Import secret as ENV and save to .ENV file
-# If build from source code ignore
-RUN if [ "$DOCKER_BUILD_VIA_WORKFLOW" = true] ; then \
-		--mount=type=secret,id=MISTRAL_API_KEY,env=MISTRAL_API_KEY \
-		echo "MISTRAL_API_KEY=${MISTRAL_API_KEY}" > /app/.env ; \
-	else \
-		echo "Please include your own API key in .env" ; \
-	fi
+# Import secret and save to .ENV file
+RUN --mount=type=secret,id=MISTRAL_API_KEY \
+		echo "MISTRAL_API_KEY=$(cat /run/secrets/MISTRAL_API_KEY)" > /app/.env
 
 # Import secret as ENV and save to .ENV file
 #RUN --mount=type=secret,id=MISTRAL_API_KEY,env=MISTRAL_API_KEY || true \

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,17 @@ ENV PYTHONDONTWRITEBYTECODE=1
 WORKDIR /app
 
 # Import secret as ENV and save to .ENV file
-RUN --mount=type=secret,id=MISTRAL_API_KEY,env=MISTRAL_API_KEY \
-	echo "MISTRAL_API_KEY=${MISTRAL_API_KEY}" > /app/.env
+# If build from source code ignore
+RUN if [ "$DOCKER_BUILD_VIA_WORKFLOW" = true] ; then \
+		--mount=type=secret,id=MISTRAL_API_KEY,env=MISTRAL_API_KEY \
+		echo "MISTRAL_API_KEY=${MISTRAL_API_KEY}" > /app/.env ; \
+	else \
+		echo "Please include your own API key in .env" ; \
+	fi
+
+# Import secret as ENV and save to .ENV file
+#RUN --mount=type=secret,id=MISTRAL_API_KEY,env=MISTRAL_API_KEY || true \
+#	echo "MISTRAL_API_KEY=${MISTRAL_API_KEY}" > /app/.env
 
 # Update and install necessary packages
 RUN apt-get update && apt-get install -y \


### PR DESCRIPTION
--mount=type causes an error when designating it as ENV when no secret is passed

* Changed ENV into Secret file which raises no error when secret isn't passed
    * This allows for source code building now
* If user has `.ENV` file when building from source code it will override the secret passed.