### PR TITLE
Apache juypter configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -66,7 +66,15 @@ ENV STREAMLIT_SERVER_PORT=5001
 # Streamlit port
 EXPOSE 5001
 # Jupyter Notebook port
-#EXPOSE 6001
+EXPOSE 6001
+
+# Create a Jupyter config file to disable token authentication
+RUN jupyter notebook --generate-config && \
+    echo "c.NotebookApp.token = ''" >> /root/.jupyter/jupyter_notebook_config.py && \
+    echo "c.NotebookApp.password = ''" >> /root/.jupyter/jupyter_notebook_config.py && \
+    echo "c.NotebookApp.ip = '0.0.0.0'" >> /root/.jupyter/jupyter_notebook_config.py && \
+    echo "c.NotebookApp.port = 6001" >> /root/.jupyter/jupyter_notebook_config.py && \
+    echo "c.NotebookApp.open_browser = False" >> /root/.jupyter/jupyter_notebook_config.py
 
 # Add the conda environment's bin directory to PATH
 ENV PATH=/opt/miniforge/envs/team1_env/bin:$PATH

--- a/README.md
+++ b/README.md
@@ -90,6 +90,10 @@ Once the Docker container is running, you can access the IT Support Chatbot thro
 
 [http://localhost:5001/team1](http://localhost:5001/team1) or [http://127.0.0.1:5001/team1](http://127.0.0.1:5001/team1)
 
+You can access the Jupyter Notebook at:
+
+[http://localhost:6001/jupyter](http://localhost:6001/jupyter) or [http://127.0.0.1:6001/jupyter](http://127.0.0.1:6001/jupyter)
+
 ---
 
 ### Troubleshooting

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Before you begin, ensure you have the following installed on your machine:
    Run the Docker container with the following command:
 
    ```bash
-   docker run -d -p 5001:5001 team1_app
+   docker run -d -p 5001:5001 -p 6001:6001 team1_app
    ```
 
 ### Accessing the Application

--- a/app.py
+++ b/app.py
@@ -146,5 +146,5 @@ if __name__ == "__main__":
     else:
         os.environ["STREAMLIT_RUNNING"] = "1"  # Set the environment variable to indicate Streamlit is running
 		#if multiple processes are being started, you must use Popen followed by run subprocess!
-        subprocess.run(["streamlit", "run", __file__, "--server.port=5001", "--server.address=0.0.0.0", "--server.baseUrlPath=/team1"])
-        #subprocess.run(["jupyter", "notebook", "--ip=0.0.0.0", "--port=6001", "--no-browser", "--allow-root"])
+        subprocess.Popen(["streamlit", "run", __file__, "--server.port=5001", "--server.address=0.0.0.0", "--server.baseUrlPath=/team1"])
+        subprocess.run(["jupyter", "notebook", "--ip=0.0.0.0", "--port=6001", "--no-browser", "--allow-root", "--NotebookApp.base_url=/jupyter"])


### PR DESCRIPTION
Set juypter notebook to run on port 6001. Juypter notebook can be acessed at http://localhost:6001/jupyter or http://127.0.0.1:6001/jupyter. Runs on linux VM Apache server with additional config for port 6001. Professor would have to give access to port 6001 in the Apache config to work. Right now there is no password required to access the juypter notebook, can change in the future. Test it out and let me know if you have any issues. 