### PR TITLE
Fixes upload to DockerHub when pull-request to main is created

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -3,10 +3,6 @@ name: ci
 on:
   push:
     branches:
-      - Docker-mount-fix
-      - main
-  pull_request:
-    branches:
       - main
 
 jobs:


### PR DESCRIPTION
Fixes an error that causes the pull-requests to automatically update the DockerHub image.
* This prevents unwanted writing over the image if the pull-request is denied
    * Still will automatically proc on push to main