### PR TITLE
Temporary removed NeMo's from installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,8 +53,8 @@ COPY requirements.txt /app/requirements.txt
 RUN mamba install --yes --file requirements.txt && mamba clean --all -f -y
 
 # Install Python packages not on Mamba DB
-RUN pip install -qU cython
-RUN pip install -qU langchain_milvus nemo-curator nemoguardrails
+#RUN pip install -qU cython
+RUN pip install -qU langchain_milvus #nemo-curator nemoguardrails
 
 # Copy the current directory contents into the container at /app
 COPY . /app


### PR DESCRIPTION
Temporary removed NeMo's and cython from installation due to conflicts with NeMo and Mac architecture. 