### PR TITLE
[DO NOT MERGE] added another call to llm to recheck the response

### DIFF
--- a/RAG.py
+++ b/RAG.py
@@ -134,10 +134,12 @@ def query_rag(query):
         # Add the source to the response if available
         if isinstance(source, str) and source != "Unknown":
             if score <= 0.4:
-                result = is_answer_relevant(model, response, most_relevant_document.page_content)
+                result = is_answer_relevant(model, response, retrieved_documents)
                 if result is False:
                     response = "I don't have enough information to answer this question."
                     source = None
+                else:
+                    response += f"\n\nSource: [{title}]({source})"
             print("Response Generated")
         
         return response, source


### PR DESCRIPTION
While retrieving the relevant documents from the database, we get a similarity score for each chunk of data.
If the similarity score is less than a threshold (which in this case is 0.4), we call the API with a different prompt that is meant for rechecking if the response given by the first call is taken from the retrieved documents or not

New functions for answer verification:

* [`RAG.py`](diffhunk://#diff-b4d3e9b04b00f176789c5ef0a3760957d6d7cd9dd54da08d55639c0e950ab5a3R39-R89): Added the `recheck_prompt` function to create a prompt template for verifying if an answer is fully supported by the given context.
* [`RAG.py`](diffhunk://#diff-b4d3e9b04b00f176789c5ef0a3760957d6d7cd9dd54da08d55639c0e950ab5a3R39-R89): Added the `is_answer_relevant` function to call the Mistral LLM and check if the answer is based on the provided context.

Enhancements to `query_rag` function:

* [`RAG.py`](diffhunk://#diff-b4d3e9b04b00f176789c5ef0a3760957d6d7cd9dd54da08d55639c0e950ab5a3R125): Added retrieval of the `score` metadata from the most relevant document.
* [`RAG.py`](diffhunk://#diff-b4d3e9b04b00f176789c5ef0a3760957d6d7cd9dd54da08d55639c0e950ab5a3R137-R141): Integrated the `is_answer_relevant` function to verify the generated answer if the score is less than or equal to 0.4 and updated the response accordingly if the answer is deemed irrelevant.