### PR TITLE
Add clickable title for Confusion Matrix in sidebar

### DIFF
--- a/app.py
+++ b/app.py
@@ -73,7 +73,7 @@ def display_performance_metrics():
     
     # Title with clickable text
     st.sidebar.markdown(
-        '<a href="https://github.com/DrAlzahraniProjects/csusb_fall2024_cse6550_team1?tab=readme-ov-file#software-quality-assurance-for-the-it-chatbot" style="text-decoration: none; font-size: 24px; color: black;">Confusion Matrix</a>',
+        '<a href="https://github.com/DrAlzahraniProjects/csusb_fall2024_cse6550_team1?tab=readme-ov-file#software-quality-assurance-for-the-it-chatbot" class="sidebar-heading">Confusion Matrix</a>',
         unsafe_allow_html=True,
     )
 

--- a/app.py
+++ b/app.py
@@ -70,7 +70,13 @@ def display_performance_metrics():
     """
     Display performance metrics in the sidebar.
     """
-    st.sidebar.title("Confusion Matrix")
+    
+    # Title with clickable text
+    st.sidebar.markdown(
+        '<a href="https://github.com/DrAlzahraniProjects/csusb_fall2024_cse6550_team1?tab=readme-ov-file#software-quality-assurance-for-the-it-chatbot" style="text-decoration: none; font-size: 24px; color: black;">Confusion Matrix</a>',
+        unsafe_allow_html=True,
+    )
+
     important_metrics = [
         ("Sensitivity", "sensitivity"),
         ("Specificity", "specificity"),

--- a/assets/style.css
+++ b/assets/style.css
@@ -29,6 +29,13 @@ div[data-testid="stVerticalBlock"] div:has(div.fixed-header) {
     float: right;
 }
 
+.sidebar-heading {
+    text-decoration: none; 
+    font-size: 30px; 
+    font-weight: bold;
+    color: black !important;
+}
+
 .assistant-message {
     text-align: left;
     background-color: #e8f4ff;


### PR DESCRIPTION
updated the "Confusion Matrix" title as a clickable title. Now it redirects to SQA questions in readme page.