### PR TITLE
Added cookies DDOS protection 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,7 @@ COPY requirements.txt /app/requirements.txt
 RUN mamba install --yes --file requirements.txt && mamba clean --all -f -y
 
 # Install Python packages not on Mamba DB
-RUN pip install -qU langchain_milvus
+RUN pip install -qU langchain_milvus extra_streamlit_components
 
 
 # Copy the current directory contents into the container at /app

--- a/ddos_protection.py
+++ b/ddos_protection.py
@@ -1,6 +1,11 @@
 import time
+import random
 from collections import defaultdict
 import streamlit as st
+import extra_streamlit_components as stx
+
+cookie_manager = stx.CookieManager()
+random.seed(1)
 
 # Store user request information in session state
 if 'user_requests' not in st.session_state:
@@ -10,7 +15,9 @@ if 'user_requests' not in st.session_state:
 def get_remote_ip():
     # You can substitute this with a different method if you need to access headers directly, 
     # or use a proxy like NGINX that passes the client IP in a header.
-    return "user_ip"  # Substitute this with actual IP fetching logic (like from request headers)
+    if cookie_manager.get(cookie='user_id') is None:
+        cookie_manager.set('user_id', random.randrange(0, 10000))
+    return cookie_manager.get(cookie='user_id')  # Substitute this with actual IP fetching logic (like from request headers)
 
 # Rate limit checker function
 def is_rate_limited(user_ip):
@@ -32,6 +39,10 @@ def is_rate_limited(user_ip):
 
 # Function to handle request rate limiting
 def handle_rate_limiting():
+    # Store user request information in session state
+    if 'user_requests' not in st.session_state:
+        st.session_state.user_requests = defaultdict(list)
+
     user_ip = get_remote_ip()
 
     # Check if the user is rate-limited


### PR DESCRIPTION
Added cookie creation and reading instead of IP grabbing. 

IP grabbing seems to be a very annoying subject since getting IPs is usually frowned upon. Setting up an IP grabber was much harder than just creating cookies for the user.

@acraig07 @ACraig7 I did not want to push this change overtop of yours incase we decided that cookies wasn't the best approach. 

But if this change looks good we can merge to `DDOS_protection` then merge all to `Dev`

also added a secondary check for `user_requests` that fixes and error when opening two webpages of the StreamLit on a single device.

#185 