### PR TITLE
Fix for Jupyter notebook Env

### DIFF
--- a/jupyter/documentation.ipynb
+++ b/jupyter/documentation.ipynb
@@ -69,12 +69,10 @@
       },
       "outputs": [],
       "source": [
-        "!pip install ipykernel --root-user-action=ignore\n",
-        "!pip install --user virtualenv --root-user-action=ignore --no-warn-script-location\n",
         "!apt update && apt install -y python3.10-venv\n",
         "!python3.10 -m venv chatbot\n",
-        "!source chatbot/bin/activate\n",
-        "!. chatbot/bin/activate\n",
+        "!chatbot/bin/pip install ipykernel\n",
+        "!chatbot/bin/python -m ipykernel install --user --name=chatbot\n",
         "print('Virtual Environment Created!')"
       ]
     },


### PR DESCRIPTION
Fix for Jupyter notebook Env not being created

Enviroment is properly created now. Tested and working in google collab

Logs for Jupyter Notebook.

`Get:1 http://security.ubuntu.com/ubuntu jammy-security InRelease [129 kB]
Hit:2 http://archive.ubuntu.com/ubuntu jammy InRelease
Hit:3 https://cloud.r-project.org/bin/linux/ubuntu jammy-cran40/ InRelease
Get:4 http://archive.ubuntu.com/ubuntu jammy-updates InRelease [128 kB]
Hit:5 https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64  InRelease
Get:6 http://archive.ubuntu.com/ubuntu jammy-backports InRelease [127 kB]
Hit:7 https://r2u.stat.illinois.edu/ubuntu jammy InRelease
Hit:8 https://ppa.launchpadcontent.net/deadsnakes/ppa/ubuntu jammy InRelease
Hit:9 https://ppa.launchpadcontent.net/graphics-drivers/ppa/ubuntu jammy InRelease
Hit:10 https://ppa.launchpadcontent.net/ubuntugis/ppa/ubuntu jammy InRelease
Fetched 384 kB in 2s (220 kB/s)
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
49 packages can be upgraded. Run 'apt list --upgradable' to see them.
W: Skipping acquire of configured file 'main/source/Sources' as repository 'https://r2u.stat.illinois.edu/ubuntu jammy InRelease' does not seem to provide it (sources.list entry misspelt?)
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
python3.10-venv is already the newest version (3.10.12-1~22.04.7).
0 upgraded, 0 newly installed, 0 to remove and 49 not upgraded.
Requirement already satisfied: ipykernel in ./chatbot/lib/python3.10/site-packages (6.29.5)
Requirement already satisfied: jupyter-core!=5.0.*,>=4.12 in ./chatbot/lib/python3.10/site-packages (from ipykernel) (5.7.2)
Requirement already satisfied: jupyter-client>=6.1.12 in ./chatbot/lib/python3.10/site-packages (from ipykernel) (8.6.3)
Requirement already satisfied: ipython>=7.23.1 in ./chatbot/lib/python3.10/site-packages (from ipykernel) (8.29.0)
Requirement already satisfied: tornado>=6.1 in ./chatbot/lib/python3.10/site-packages (from ipykernel) (6.4.2)
Requirement already satisfied: pyzmq>=24 in ./chatbot/lib/python3.10/site-packages (from ipykernel) (26.2.0)
Requirement already satisfied: packaging in ./chatbot/lib/python3.10/site-packages (from ipykernel) (24.2)
Requirement already satisfied: nest-asyncio in ./chatbot/lib/python3.10/site-packages (from ipykernel) (1.6.0)
Requirement already satisfied: matplotlib-inline>=0.1 in ./chatbot/lib/python3.10/site-packages (from ipykernel) (0.1.7)
Requirement already satisfied: comm>=0.1.1 in ./chatbot/lib/python3.10/site-packages (from ipykernel) (0.2.2)
Requirement already satisfied: debugpy>=1.6.5 in ./chatbot/lib/python3.10/site-packages (from ipykernel) (1.8.9)
Requirement already satisfied: psutil in ./chatbot/lib/python3.10/site-packages (from ipykernel) (6.1.0)
Requirement already satisfied: traitlets>=5.4.0 in ./chatbot/lib/python3.10/site-packages (from ipykernel) (5.14.3)
Requirement already satisfied: typing-extensions>=4.6 in ./chatbot/lib/python3.10/site-packages (from ipython>=7.23.1->ipykernel) (4.12.2)
Requirement already satisfied: jedi>=0.16 in ./chatbot/lib/python3.10/site-packages (from ipython>=7.23.1->ipykernel) (0.19.2)
Requirement already satisfied: pexpect>4.3 in ./chatbot/lib/python3.10/site-packages (from ipython>=7.23.1->ipykernel) (4.9.0)
Requirement already satisfied: pygments>=2.4.0 in ./chatbot/lib/python3.10/site-packages (from ipython>=7.23.1->ipykernel) (2.18.0)
Requirement already satisfied: stack-data in ./chatbot/lib/python3.10/site-packages (from ipython>=7.23.1->ipykernel) (0.6.3)
Requirement already satisfied: exceptiongroup in ./chatbot/lib/python3.10/site-packages (from ipython>=7.23.1->ipykernel) (1.2.2)
Requirement already satisfied: decorator in ./chatbot/lib/python3.10/site-packages (from ipython>=7.23.1->ipykernel) (5.1.1)
Requirement already satisfied: prompt-toolkit<3.1.0,>=3.0.41 in ./chatbot/lib/python3.10/site-packages (from ipython>=7.23.1->ipykernel) (3.0.48)
Requirement already satisfied: python-dateutil>=2.8.2 in ./chatbot/lib/python3.10/site-packages (from jupyter-client>=6.1.12->ipykernel) (2.9.0.post0)
Requirement already satisfied: platformdirs>=2.5 in ./chatbot/lib/python3.10/site-packages (from jupyter-core!=5.0.*,>=4.12->ipykernel) (4.3.6)
Requirement already satisfied: parso<0.9.0,>=0.8.4 in ./chatbot/lib/python3.10/site-packages (from jedi>=0.16->ipython>=7.23.1->ipykernel) (0.8.4)
Requirement already satisfied: ptyprocess>=0.5 in ./chatbot/lib/python3.10/site-packages (from pexpect>4.3->ipython>=7.23.1->ipykernel) (0.7.0)
Requirement already satisfied: wcwidth in ./chatbot/lib/python3.10/site-packages (from prompt-toolkit<3.1.0,>=3.0.41->ipython>=7.23.1->ipykernel) (0.2.13)
Requirement already satisfied: six>=1.5 in ./chatbot/lib/python3.10/site-packages (from python-dateutil>=2.8.2->jupyter-client>=6.1.12->ipykernel) (1.16.0)
Requirement already satisfied: asttokens>=2.1.0 in ./chatbot/lib/python3.10/site-packages (from stack-data->ipython>=7.23.1->ipykernel) (2.4.1)
Requirement already satisfied: pure-eval in ./chatbot/lib/python3.10/site-packages (from stack-data->ipython>=7.23.1->ipykernel) (0.2.3)
Requirement already satisfied: executing>=1.2.0 in ./chatbot/lib/python3.10/site-packages (from stack-data->ipython>=7.23.1->ipykernel) (2.1.0)
Installed kernelspec chatbot in /root/.local/share/jupyter/kernels/chatbot
Virtual Environment Created!` 